### PR TITLE
correct link to flat_medium image

### DIFF
--- a/tutorial/projections_crs_and_terms.ipynb
+++ b/tutorial/projections_crs_and_terms.ipynb
@@ -57,7 +57,7 @@
     " * Paper\n",
     " * Screen\n",
     "\n",
-    "![](static/flat_medium.jpg)\n"
+    "![](../static/flat_medium.jpg)\n"
    ]
   },
   {


### PR DESCRIPTION
Thanks for this excellent tutorial. I am currently in the process of adapting some of the material for my [research computing in earth science](https://rabernat.github.io/research_computing_2018/) class.

I discovered a tiny error in one of the image links.